### PR TITLE
Add active hours logic

### DIFF
--- a/app/tracker.py
+++ b/app/tracker.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from logging import getLogger
 import time
 from re import compile
 from typing import TYPE_CHECKING
 
-from config import SCAN_INTERVAL, SCAN_TIMEOUT, SUBNETS
+from config import SCAN_INTERVAL, SCAN_TIMEOUT, SUBNETS, ACTIVE_HOURS
 from app.exceptions import NmapScanError
 
 if TYPE_CHECKING:
@@ -80,6 +81,10 @@ class Tracker:
         while True:
             _log.debug("Sleeping for %ds.", SCAN_INTERVAL)
             await asyncio.sleep(SCAN_INTERVAL)
+
+            if datetime.now().hour not in ACTIVE_HOURS:
+                _log.debug("We are outside of active hours. Skipping loop iteration...")
+                continue
 
             try:
                 devices = await self._scan_subnets(SUBNETS)

--- a/app/tracker.py
+++ b/app/tracker.py
@@ -82,7 +82,7 @@ class Tracker:
             _log.debug("Sleeping for %ds.", SCAN_INTERVAL)
             await asyncio.sleep(SCAN_INTERVAL)
 
-            if datetime.now().hour not in ACTIVE_HOURS:
+            if not ACTIVE_HOURS[1] >= datetime.now().hour >= ACTIVE_HOURS[0]:
                 _log.debug("We are outside of active hours. Skipping loop iteration...")
                 continue
 

--- a/config.py
+++ b/config.py
@@ -21,7 +21,7 @@ SUBNETS = ("192.168.0.*",)
 # ACTIVE_HOURS: A range of hours (in 24-hour format) when the scanner will be active.
 # If the scanner finds we are outside of active hours, it will effectively "hibernate" and stop performing all related routines.
 # Values are set in 24-hour format; e.g., 22 means 10:00 PM.
-ACTIVE_HOURS = range(15, 21)
+ACTIVE_HOURS = (15, 21)
 
 # SCAN_INTERVAL: The interval, in seconds, between each scan of the network.
 # This value controls how frequently the network is scanned for user devices.

--- a/config.py
+++ b/config.py
@@ -18,6 +18,11 @@ DATABASE = "app/db/users.db"
 # all devices in the "192.168.0.x" IP range will be scanned.
 SUBNETS = ("192.168.0.*",)
 
+# ACTIVE_HOURS: A range of hours (in 24-hour format) when the scanner will be active.
+# If the scanner finds we are outside of active hours, it will effectively "hibernate" and stop performing all related routines.
+# Values are set in 24-hour format; e.g., 22 means 10:00 PM.
+ACTIVE_HOURS = range(15, 21)
+
 # SCAN_INTERVAL: The interval, in seconds, between each scan of the network.
 # This value controls how frequently the network is scanned for user devices.
 SCAN_INTERVAL = 60


### PR DESCRIPTION
Add logic to hibernate when the scanner is outside of active hours.
This is in order to help save on network bandwidth